### PR TITLE
:wrench: Fix: mongo version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   mongo:
-    image: mongo
+    image: mongo:5.0.9
     restart: always
     ports:
       - 27017:27017


### PR DESCRIPTION
最新の mongo version だと `fail to get db collection no reachable servers` error が起こるようなので db version を固定https://github.com/GincoInc/sre-dev/issues/1060